### PR TITLE
fix docs crate name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 pyroscope = "0.5.0"
-pyroscope-pprofrs = "0.2"
+pyroscope_pprofrs = "0.2"
 ```
 
 Include Pyroscope and pprof-rs dependencies:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```toml
 //! [dependencies]
 //! pyroscope = "0.5"
-//! pyroscope-pprofrs = "0.2"
+//! pyroscope_pprofrs = "0.2"
 //! ```
 //!
 //! ## Configure a Pyroscope Agent


### PR DESCRIPTION
I was surprised when I got the following error when I copied the crate reference from the document
```
error: no matching package found
searched package name: `pyroscope-pprofrs`
perhaps you meant:      pyroscope_pprofrs
location searched: registry `crates-io`
```
The  `pyroscope-pprofrs` in the document may be a typo.
https://crates.io/crates/pyroscope_pprofrs
